### PR TITLE
fix(file_operations): Use context to ensure deletion

### DIFF
--- a/modelhouse/storage/file_operations.py
+++ b/modelhouse/storage/file_operations.py
@@ -3,9 +3,9 @@ import os
 from . import Storage
 
 def get_files_and_contents(path):
-    store = Storage(path)
-    files = store.list_files(flat=False)
-    read_files = store.get_files(files)
+    with Storage(path) as store:
+        files = store.list_files(flat=False)
+        read_files = store.get_files(files)
 
     files_and_contents = []
     for read_file in read_files:
@@ -18,10 +18,10 @@ def get_files_and_contents(path):
     return files_and_contents
 
 def put_files_and_contents(path, files_and_contents):
-    store = Storage(path)
-    store.put_files(
-            files_and_contents,
-            content_type='application/octet-stream',
-            compress=None,
-            cache_control='no-cache'
-    )
+    with Storage(path) as store:
+        store.put_files(
+                files_and_contents,
+                content_type='application/octet-stream',
+                compress=None,
+                cache_control='no-cache'
+        )


### PR DESCRIPTION
`Storage` object is not properly destroyed at the end of the `get_files_and_contents` functions, and continues to waste CPU cycles polling from the underlying `ThreadedQueue` (I think). Using the context manager avoids this issue.