### PR TITLE
fix: default google credentials

### DIFF
--- a/modelhouse/storage/secretmanager.py
+++ b/modelhouse/storage/secretmanager.py
@@ -75,7 +75,7 @@ class SecretManager():
 
         if google_credentials == None:
             warnings.warn('Using default Google credentials. \
-                    There is no {} google-secret.json set.'.format(secrets_folder))
+                    There is no {} google-secret.json set.'.format(self.secrets_folder))
         else:
             self.google_credentials_cache[bucket] = \
                     (project_name, google_credentials)


### PR DESCRIPTION
The default google creds code currently references a variable that's not defined in its scope. This just fixes the reference to the class variable instead.